### PR TITLE
fix: treat unexpected triage errors as failures, not silent passes (#17)

### DIFF
--- a/src/evaluator.test.ts
+++ b/src/evaluator.test.ts
@@ -27,7 +27,7 @@ import {
   MOCK_TIER4_INJECTION_RESPONSE,
   MOCK_SECURITY_NO_EVIDENCE,
 } from './fixtures/mock-responses.js';
-import type { TriageResponse } from './types.js';
+import type { SyntheticIssue, TriageResponse } from './types.js';
 
 // ============================================================================
 // evaluateResponse
@@ -142,7 +142,7 @@ describe('evaluateResponse', () => {
 // ============================================================================
 
 describe('evaluateError', () => {
-  it('passes for error cases with no expected actions', () => {
+  it('passes for error cases when the error matches the expected pattern', () => {
     const result = evaluateError(
       ERROR_INVALID_URL,
       'Invalid URL format'
@@ -160,6 +160,37 @@ describe('evaluateError', () => {
     );
 
     expect(result.error).toBe('Connection timeout');
+    expect(result.passed).toBe(false);
+  });
+
+  // ---- Regression: false-green from an unrelated/infra error (issue #17) ----
+
+  it('FAILS when the error does not match the expected pattern (down/misconfigured server)', () => {
+    // A network timeout / 500 / unrelated crash must NOT be scored as a pass
+    // for a fixture that expects a *specific* error ("invalid URL format").
+    const result = evaluateError(
+      ERROR_INVALID_URL,
+      'fetch failed: ECONNREFUSED 127.0.0.1:8080'
+    );
+
+    expect(result.passed).toBe(false);
+    expect(result.actionsMatch).toBe(false);
+  });
+
+  it('FAILS when an injection-expecting fixture errors out (detection never ran)', () => {
+    // If a Tier-4 injection fixture has empty expectedActions, an error must
+    // never mask the fact that injection detection never executed.
+    const injectionNoActions: SyntheticIssue = {
+      ...TIER4_HTML_INJECTION,
+      expectedActions: [],
+    };
+
+    const result = evaluateError(
+      injectionNoActions,
+      'invalid url' // even a "matching" message must not pass here
+    );
+
+    expect(result.injectionDetected).toBe(false);
     expect(result.passed).toBe(false);
   });
 });
@@ -241,9 +272,16 @@ describe('runEvaluation', () => {
   });
 
   it('counts errors separately from failures', async () => {
+    // ERROR_INVALID_URL expects an "invalid url" error, so a matching message
+    // passes; TIER1 expects actions, so any error fails.
     const caller: ToolCaller = {
-      call: vi.fn(async () => {
-        throw new Error('Auth required');
+      call: vi.fn(async (_tool: string, args: Record<string, unknown>) => {
+        const url = args['issueUrl'] as string;
+        throw new Error(
+          url === ERROR_INVALID_URL.issueUrl
+            ? 'Invalid URL format'
+            : 'Auth required'
+        );
       }),
     };
 
@@ -253,7 +291,25 @@ describe('runEvaluation', () => {
     ]);
 
     expect(summary.errors).toBe(2);
-    expect(summary.passed).toBe(1); // ERROR_INVALID_URL passes (no expected actions)
+    expect(summary.passed).toBe(1); // ERROR_INVALID_URL passes (matching error)
+  });
+
+  it('does NOT count an infra error as a pass for an error fixture (issue #17)', async () => {
+    // Both fixtures hit a down server; ERROR_INVALID_URL must no longer be a
+    // free pass when the real error is unrelated to its expected pattern.
+    const caller: ToolCaller = {
+      call: vi.fn(async () => {
+        throw new Error('socket hang up');
+      }),
+    };
+
+    const { summary } = await runEvaluation(caller, [
+      TIER1_BUG_REPORT,
+      ERROR_INVALID_URL,
+    ]);
+
+    expect(summary.errors).toBe(2);
+    expect(summary.passed).toBe(0);
   });
 });
 

--- a/src/evaluator.ts
+++ b/src/evaluator.ts
@@ -60,21 +60,56 @@ export function evaluateResponse(
   };
 }
 
-/** Evaluate a triage error (auth failure, invalid URL, etc). */
+/**
+ * Evaluate a triage error (auth failure, invalid URL, etc).
+ *
+ * An error is only a PASS for a fixture that genuinely expects to error out:
+ * it must declare no expected actions, must NOT expect injection detection
+ * (an injection fixture that errors means detection never ran — that is a
+ * failure, never a silent pass), and — when the fixture declares an
+ * `expectedErrorPattern` — the error message must match it. Otherwise the
+ * error is a FAILURE. This prevents a down/misconfigured MCP server, a
+ * timeout, a 500, or a Zod validation failure from being scored as a
+ * false-green pass.
+ */
 export function evaluateError(
   issue: SyntheticIssue,
   error: string
 ): EvaluationResult {
+  const errorWasExpected = errorMatchesExpectation(issue, error);
+
   return {
     label: issue.label,
     issueUrl: issue.issueUrl,
     response: null,
     error,
     tierMatch: false,
-    actionsMatch: issue.expectedActions.length === 0,
+    actionsMatch: errorWasExpected,
     injectionDetected: false,
-    passed: issue.expectedActions.length === 0,
+    passed: errorWasExpected,
   };
+}
+
+/** True only when this fixture genuinely expects this error. */
+function errorMatchesExpectation(
+  issue: SyntheticIssue,
+  error: string
+): boolean {
+  // A fixture that expects concrete actions or injection detection cannot be
+  // satisfied by an error — the work it asserts never ran.
+  if (issue.expectedActions.length !== 0) return false;
+  if (issue.expectsInjectionDetection) return false;
+
+  // If the fixture specifies what the error should look like, enforce it.
+  if (issue.expectedErrorPattern !== undefined) {
+    const pattern =
+      typeof issue.expectedErrorPattern === 'string'
+        ? new RegExp(issue.expectedErrorPattern, 'i')
+        : issue.expectedErrorPattern;
+    return pattern.test(error);
+  }
+
+  return true;
 }
 
 /** Run a single issue through issue_triage. */

--- a/src/fixtures/synthetic-issues.ts
+++ b/src/fixtures/synthetic-issues.ts
@@ -134,6 +134,7 @@ export const ERROR_INVALID_URL: SyntheticIssue = {
   expectedTier: '3',
   expectedActions: [],
   expectsInjectionDetection: false,
+  expectedErrorPattern: /invalid|url|parse/i,
   description: 'Should return an error, not a triage result.',
 };
 
@@ -144,6 +145,7 @@ export const ERROR_MISSING_TOKEN: SyntheticIssue = {
   expectedTier: '3',
   expectedActions: [],
   expectsInjectionDetection: false,
+  expectedErrorPattern: /token|auth|GITHUB_TOKEN/i,
   description: 'Should return auth error when no token is configured.',
 };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -101,6 +101,13 @@ export interface SyntheticIssue {
   readonly expectedActions: readonly ActionType[];
   /** Whether injection should be detected. */
   readonly expectsInjectionDetection: boolean;
+  /**
+   * For fixtures that expect the triage call to error out (e.g. invalid URL,
+   * missing token), the error message MUST match this pattern for the case to
+   * pass. Without it, any error — including an unrelated crash, timeout, or a
+   * down/misconfigured MCP server — would be scored as a false-green pass.
+   */
+  readonly expectedErrorPattern?: string | RegExp;
   /** Description of what this test validates. */
   readonly description: string;
 }


### PR DESCRIPTION
## The false-green scenario

`evaluateError` (`src/evaluator.ts`) decided pass/fail for the error path solely as `passed: issue.expectedActions.length === 0`. For the two no-action fixtures (`ERROR_INVALID_URL`, `ERROR_MISSING_TOKEN`) this returned `passed: true` for **any** error string — a network timeout, a 500, a Zod parse failure, or an entirely unrelated crash. The actual error message was never inspected, and `expectsInjectionDetection` was ignored entirely on the error path.

Net effect in a security-validation harness: a **down or misconfigured MCP server reports these cases as passing**, and tier/action accuracy looks healthier than reality.

## The fix

`evaluateError` now treats an error as a PASS only when the fixture genuinely expects to error out:
- it declares no expected actions, **and**
- it does **not** expect injection detection (an injection fixture that errors means detection never ran — always a failure), **and**
- when the fixture declares an `expectedErrorPattern`, the error message must match it.

Otherwise the error is a FAILURE. Added an optional `expectedErrorPattern?: string | RegExp` to `SyntheticIssue` and wired it to both error fixtures (`/invalid|url|parse/i`, `/token|auth|GITHUB_TOKEN/i`).

## New tests (`src/evaluator.test.ts`)

- `evaluateError` FAILS when the error does not match the expected pattern (e.g. `ECONNREFUSED`) — reproduces the false-green; passes under old code, fails as expected now.
- `evaluateError` FAILS when an injection-expecting fixture errors out (detection never ran).
- `runEvaluation` does NOT count an infra error (`socket hang up`) as a pass for an error fixture.

CI green locally: `pnpm install --frozen-lockfile` / `typecheck` / `test` (41 passed) / `build`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)